### PR TITLE
Replaced deprecated RAND_pseudo_bytes with RAND_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ local token = random.token(10)
 
 ## About The Internals
 
-For random bytes `lua-resty-random` uses OpenSSL `RAND_pseudo_bytes` that is included in OpenResty (or Nginx) when compiled with OpenSSL. For random numbers the library uses Lua's `math.random`, and `math.randomseed`. You should note that on LuaJIT environment, LuaJIT uses a Tausworthe PRNG with period 2^223 to implement `math.random` and `math.randomseed`. Hexadecimal dumps are implemented using `ngx_hex_dump`.
+For random bytes `lua-resty-random` uses OpenSSL `RAND_bytes` that is included in OpenResty (or Nginx) when compiled with OpenSSL. For random numbers the library uses Lua's `math.random`, and `math.randomseed`. You should note that on LuaJIT environment, LuaJIT uses a Tausworthe PRNG with period 2^223 to implement `math.random` and `math.randomseed`. Hexadecimal dumps are implemented using `ngx_hex_dump`.
 
 ## Lua API
 #### string random.bytes(len, format)
 
-Returns `len` number of random bytes using OpenSSL `RAND_pseudo_bytes`. You may optionally pass `"hex"` as format argument if you want random bytes hexadecimal encoded.
+Returns `len` number of random bytes using OpenSSL `RAND_bytes`. You may optionally pass `"hex"` as format argument if you want random bytes hexadecimal encoded.
 
 ##### Example
 

--- a/lib/resty/random.lua
+++ b/lib/resty/random.lua
@@ -12,7 +12,7 @@ local concat     = table.concat
 ffi_cdef[[
 typedef unsigned char u_char;
 u_char * ngx_hex_dump(u_char *dst, const u_char *src, size_t len);
-int RAND_pseudo_bytes(u_char *buf, int num);
+int RAND_bytes(u_char *buf, int num);
 ]]
 
 local ok, new_tab = pcall(require, "table.new")
@@ -32,14 +32,14 @@ local t = ffi_typeof("uint8_t[?]")
 
 local function bytes(len, format)
     local s = ffi_new(t, len)
-    local strong = C.RAND_pseudo_bytes(s, len) == 1
+    C.RAND_bytes(s, len)
     if not s then return nil,false end
     if format == 'hex' then
         local b = ffi_new(t, len * 2)
         C.ngx_hex_dump(b, s, len)
-        return ffi_str(b, len * 2),strong
+        return ffi_str(b, len * 2),true
     else
-        return ffi_str(s, len),strong
+        return ffi_str(s, len),true
     end
 end
 


### PR DESCRIPTION
Thanks for your work! Just a small change, which pretty much speaks for itself:

>  RAND_pseudo_bytes() has been deprecated. Users should use RAND_bytes() instead. 

– [OpenSSL manual on RAND_bytes()](https://www.openssl.org/docs/manmaster/crypto/RAND_bytes.html)
